### PR TITLE
Update: Set trusted proxies as recommended by Gin

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,9 @@ import (
 func main() {
 	r := gin.Default()
 
+	// Set trusted proxies
+	_ = r.SetTrustedProxies([]string{"192.168.0.1"})
+
 	// Middleware
 	r.Use(middleware.Logger())
 


### PR DESCRIPTION
- Sets trusted proxies so Gin will not throw a warning. This can be configured easily by entering the desired values.

> [GIN-debug] [WARNING] You trusted all proxies, this is NOT safe. We recommend you to set a value.
Please check https://pkg.go.dev/github.com/gin-gonic/gin#readme-don-t-trust-all-proxies for details.
